### PR TITLE
doc: Switch documentation generation to docbook-utils

### DIFF
--- a/doc/faq/Makefile
+++ b/doc/faq/Makefile
@@ -4,5 +4,4 @@ clean :
 	rm -rf SRM-HOWTO 
 
 SRM-HOWTO/index.html : SRM-HOWTO.sgml
-	            sgmltools --backend=html SRM-HOWTO.sgml
-
+	docbook2html SRM-HOWTO.sgml -o SRM-HOWTO

--- a/doc/man/Makefile
+++ b/doc/man/Makefile
@@ -31,21 +31,11 @@ install-gzip: install-gz
 clean:
 	rm -f aboot.8 aboot.conf.5 abootconf.8 isomarkboot.1 sdisklabel.8 netabootwrap.1 manpage.log manpage.links manpage.refs
 
-aboot.8: aboot.sgml
-	nsgmls aboot.sgml | sgmlspl sgmlspl-specs/docbook2man-spec.pl
+%.1: %.sgml
+	docbook2man $<
 
-aboot.conf.5: aboot.conf.sgml
-	nsgmls aboot.conf.sgml | sgmlspl sgmlspl-specs/docbook2man-spec.pl
+%.5: %.sgml
+	docbook2man $<
 
-abootconf.8: abootconf.sgml
-	nsgmls abootconf.sgml | sgmlspl sgmlspl-specs/docbook2man-spec.pl
-
-isomarkboot.1: isomarkboot.sgml
-	nsgmls isomarkboot.sgml | sgmlspl sgmlspl-specs/docbook2man-spec.pl
-
-netabootwrap.1: netabootwrap.sgml
-	nsgmls netabootwrap.sgml | sgmlspl sgmlspl-specs/docbook2man-spec.pl
-
-sdisklabel.8: sdisklabel.sgml
-	nsgmls sdisklabel.sgml | sgmlspl sgmlspl-specs/docbook2man-spec.pl
-
+%.8: %.sgml
+	docbook2man $<

--- a/doc/man/de/Makefile
+++ b/doc/man/de/Makefile
@@ -1,33 +1,16 @@
 all:  srmbootraw.8 aboot.8 aboot.conf.5 abootconf.8 isomarkboot.1 sdisklabel.8  srmbootfat.1 netabootwrap.1
 
-aboot.8: aboot.sgml
-	nsgmls aboot.sgml | sgmlspl docbook2man-de-spec.pl
-
-aboot.conf.5: aboot.conf.sgml
-	nsgmls aboot.conf.sgml | sgmlspl docbook2man-de-spec.pl
-
-abootconf.8: abootconf.sgml
-	nsgmls abootconf.sgml | sgmlspl docbook2man-de-spec.pl
-
-isomarkboot.1: isomarkboot.sgml
-	nsgmls isomarkboot.sgml | sgmlspl docbook2man-de-spec.pl
-
-netabootwrap.1: netabootwrap.sgml
-	nsgmls netabootwrap.sgml | sgmlspl docbook2man-de-spec.pl
-
-sdisklabel.8: sdisklabel.sgml
-	nsgmls sdisklabel.sgml | sgmlspl docbook2man-de-spec.pl
-
-srmbootfat.1: srmbootfat.sgml
-	nsgmls srmbootfat.sgml | sgmlspl docbook2man-de-spec.pl
-
-srmbootraw.8: srmbootraw.sgml
-	nsgmls srmbootraw.sgml | sgmlspl docbook2man-de-spec.pl
-
-
 clean :
 	rm -f *.html srmbootraw.8 srmbootfat.1 sdisklabel.8 isomarkboot.8 abootconf.8 aboot.conf.5 aboot.8 netabootwrap.1 manpage.links manpage.log manpage.refs
 	rm -rf SRM-HOWTO 
 
+%.1: %.sgml
+	docbook2man -d docbook2man-de-spec.pl $<
+
+%.5: %.sgml
+	docbook2man -d docbook2man-de-spec.pl $<
+
+%.8: %.sgml
+	docbook2man -d docbook2man-de-spec.pl $<
 
 #.PHONY clean


### PR DESCRIPTION
sgmltools-lite and jade are no longer maintained upstream and in
Debian, so switch to docbook-utils which still is supported.