### PR TITLE
More documentation clean-up

### DIFF
--- a/doc/faq/Makefile
+++ b/doc/faq/Makefile
@@ -1,7 +1,7 @@
-all-html : SRM-HOWTO/index.html
+all-html: SRM-HOWTO/index.html
 
-clean :
-	rm -rf SRM-HOWTO 
+clean:
+	rm -rf SRM-HOWTO
 
 SRM-HOWTO/index.html : SRM-HOWTO.sgml
 	docbook2html SRM-HOWTO.sgml -o SRM-HOWTO

--- a/doc/man/Makefile
+++ b/doc/man/Makefile
@@ -16,16 +16,18 @@ MAN8=$(MANDIR)/man8
 
 all: aboot.8 aboot.conf.5 abootconf.8 isomarkboot.1 sdisklabel.8 netabootwrap.1
 
-install: 
+install:
 	install -d $(MAN1) $(MAN5) $(MAN8)
 	install -c isomarkboot.1 netabootwrap.1 $(MAN1)
 	install -c aboot.conf.5 $(MAN5)
-	install -c aboot.8 abootconf.8 e2writeboot.8 swriteboot.8 sdisklabel.8 $(MAN8)	
+	install -c aboot.8 abootconf.8 e2writeboot.8 swriteboot.8 sdisklabel.8 $(MAN8)
+
 install-gz: install
 	gzip -f9 $(MAN1)/isomarkboot.1 $(MAN1)/netabootwrap.1
 	gzip -f9 $(MAN5)/aboot.conf.5
 	gzip -f9 $(MAN8)/aboot.8 $(MAN8)/abootconf.8 $(MAN8)/e2writeboot.8 \
 		 $(MAN8)/swriteboot.8 $(MAN8)/sdisklabel.8
+
 install-gzip: install-gz
 
 clean:

--- a/doc/man/de/Makefile
+++ b/doc/man/de/Makefile
@@ -1,7 +1,7 @@
 all:  srmbootraw.8 aboot.8 aboot.conf.5 abootconf.8 isomarkboot.1 sdisklabel.8  srmbootfat.1 netabootwrap.1
 
 clean :
-	rm -f *.html srmbootraw.8 srmbootfat.1 sdisklabel.8 isomarkboot.8 abootconf.8 aboot.conf.5 aboot.8 netabootwrap.1 manpage.links manpage.log manpage.refs
+	rm -f *.html srmbootraw.8 srmbootfat.1 sdisklabel.8 isomarkboot.1 abootconf.8 aboot.conf.5 aboot.8 netabootwrap.1 manpage.links manpage.log manpage.refs
 	rm -rf SRM-HOWTO 
 
 %.1: %.sgml

--- a/doc/man/de/Makefile
+++ b/doc/man/de/Makefile
@@ -2,7 +2,6 @@ all:  srmbootraw.8 aboot.8 aboot.conf.5 abootconf.8 isomarkboot.1 sdisklabel.8  
 
 clean :
 	rm -f *.html srmbootraw.8 srmbootfat.1 sdisklabel.8 isomarkboot.1 abootconf.8 aboot.conf.5 aboot.8 netabootwrap.1 manpage.links manpage.log manpage.refs
-	rm -rf SRM-HOWTO 
 
 %.1: %.sgml
 	docbook2man -d docbook2man-de-spec.pl $<

--- a/doc/man/de/Makefile
+++ b/doc/man/de/Makefile
@@ -1,7 +1,7 @@
-all:  srmbootraw.8 aboot.8 aboot.conf.5 abootconf.8 isomarkboot.1 sdisklabel.8  srmbootfat.1 netabootwrap.1
+all: aboot.8 aboot.conf.5 abootconf.8 isomarkboot.1 netabootwrap.1 srmbootfat.1 srmbootraw.8 sdisklabel.8
 
-clean :
-	rm -f *.html srmbootraw.8 srmbootfat.1 sdisklabel.8 isomarkboot.1 abootconf.8 aboot.conf.5 aboot.8 netabootwrap.1 manpage.links manpage.log manpage.refs
+clean:
+	rm -f *.html aboot.8 aboot.conf.5 abootconf.8 isomarkboot.1 netabootwrap.1 srmbootfat.1 srmbootraw.8 sdisklabel.8 manpage.links manpage.log manpage.refs
 
 %.1: %.sgml
 	docbook2man -d docbook2man-de-spec.pl $<


### PR DESCRIPTION
The clean target for the German manpages contained a wrong filename and
also included SRM-HOWTO which isn't even generated for the German
documentation.

Also, clean up the formatting a bit by sorting filenames and removing
trailing spaces and adding newlines where necessary.